### PR TITLE
Fix progress regex, fix #14

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const os = require("os");
 const Readable = require("stream").Readable;
 const spawn = require("child_process").spawn;
 
-const progressRegex = /\[download\] *(.*) of (.*) at (.*) ETA (.*) */;
+const progressRegex = /\[download\] *(.*) of (.*)(?: at (.*) ETA (.*) *)?/;
 
 class YoutubeDlWrap
 {


### PR DESCRIPTION
Adjusted progress regex to make the file size and ETA optional, since they don't appear for files already downloaded